### PR TITLE
Build in external dirs, and maybe fix libstdc++ problem in Centos6

### DIFF
--- a/sh/mobs/pacbio/blasr/buildctl.sh
+++ b/sh/mobs/pacbio/blasr/buildctl.sh
@@ -78,23 +78,17 @@ set_globals() {
 	top_relbinwrap=${top_relbinwrap#/};
 	g_build_topdir_relprog="$top_relbinwrap"
 
-    g_make_cmd='
-	$g_make_exe -C "$g_src_dir"
-    '
-    g_make_cmd=$(echo $g_make_cmd)
+    g_builddir="$g_outdir"/build
+    mkdir -p "$g_builddir"
 
-    g_make_cmd='
-	    $g_make_exe -C "${g_outdir}"/build
-    '
     g_conf_cmd='
-        "$g_python_exe" "$g_src_dir/configure.py" --build-dir="${g_outdir}"/build
+        "$g_python_exe" "$g_src_dir/configure.py" --build-dir="${g_builddir}"
     '
     # Delete the old fetched git.
 	if [ -d "${g_outdir}"/build/blasr ]; then
         rm -rf "${g_outdir}"/build/blasr
     fi
 
-    g_make_cmd=$(echo $g_make_cmd)
     g_conf_cmd=$(echo $g_conf_cmd)
 }
 
@@ -173,6 +167,7 @@ build() {
     zlib_libflags="$shared_libopt -lz"
 
 set -x
+    # This runs in $g_outdir/build.
     eval "$g_conf_cmd" \
         --shared \
 	"$shared_flag" \
@@ -205,7 +200,8 @@ set -x
     GCC_LIB=\"$g_gcc_runtime_libdir_abs\" \
 	ZLIB_LIBFLAGS=\"$zlib_libflags\"
 
-    eval "$g_make_cmd" \
+    eval "$g_make_exe" -C "$g_builddir"\
+        -j4 \
 	${1+"$@"}
 set +x
 }

--- a/sh/mobs/pacbio/blasr/buildctl.sh
+++ b/sh/mobs/pacbio/blasr/buildctl.sh
@@ -2,7 +2,6 @@
 # ---- required subroutines
 set_globals() {
     # required globals:
-set -x
     g_name="blasr"
 
 	mobs_exe=$MOBS_EXE;
@@ -23,6 +22,7 @@ set -x
 	g_hdf5_rootdir_abs=$MOBS_hdf5__install_dir
 	g_zlib_rootdir_abs=$MOBS_zlib__install_dir
 	g_boost_rootdir_abs=$MOBS_boost__root_dir
+    g_gcc_runtime_libdir_abs=$MOBS_gcc__runtimelib_dir
 
 	eval g_src_dir="\$MOBS_${g_name}__src_dir"
 
@@ -202,11 +202,10 @@ set -x
 	PBBAM_LIBFLAGS=\"$pbbam_libflags\" \
 	HTSLIB_LIBFLAGS=\"$htslib_libflags\" \
 	HDF5_LIBFLAGS=\"$hdf5_libflags\" \
+    GCC_LIB=\"$g_gcc_runtime_libdir_abs\" \
 	ZLIB_LIBFLAGS=\"$zlib_libflags\"
 
     eval "$g_make_cmd" \
-        --debug=b \
-        -j4 \
 	${1+"$@"}
 set +x
 }

--- a/sh/mobs/pacbio/libblasr/buildctl.sh
+++ b/sh/mobs/pacbio/libblasr/buildctl.sh
@@ -14,10 +14,7 @@ set_globals() {
 	g_make_exe=$MOBS_make__make_exe
 
 	g_gxx_exe=$MOBS_gcc__gxx_exe
-    g_gxx_exe=/mnt/software/c/ccache/3.1.9/bin/g++
 	g_ar_exe=$MOBS_gcc__ar_exe
-
-	g_git_exe=$MOBS_git__git_exe
 
     g_gcc_runtime_libdir_abs=$MOBS_gcc__runtimelib_dir
 	g_boost_rootdir_abs=$MOBS_boost__root_dir
@@ -40,16 +37,13 @@ set_globals() {
 	eval g_installunittest_dir_abs="\$MOBS_${g_name}__installunittest_dir"
 	eval g_installunittest_dir="\$MOBS_${g_name}__installunittest_dir"
 
-    #TODO(CD): Build outside source tree. WHERE?
     g_builddir="$g_outdir/build"
     mkdir -p "$g_builddir"
-	g_git_build_topdir="$g_srcdir_abs"
-	g_git_build_srcdir="$g_git_build_topdir"
-    g_git_unittest_srcdir="$g_git_build_srcdir/../unittest"
     g_unittest_outdir="$g_outdir/unittest"
+    mkdir -p "$g_unittest_outdir"
 
     g_conf_cmd='
-	"$g_git_build_srcdir"/../configure.py
+	"$g_srcdir_abs"/../configure.py
     '
     g_conf_cmd=$(echo $g_conf_cmd)
 }
@@ -109,7 +103,7 @@ set -x
 	LIBPBIHDF_LIB="${g_outdir_abs}/deplinks/libpbihdf/lib/" \
 	${1+"$@"}
 
-    eval "$g_make_exe" \
+    eval "$g_make_exe" -C "$g_builddir" \
         -j4 \
         libblasr.so
 set +x
@@ -179,11 +173,11 @@ install_build() {
     #        we need to export to other programs that depend on libblasr??
     for i in . utils statistics tuples format files suffixarray ipc bwt datastructures/anchoring datastructures/alignment datastructures/alignmentset algorithms/alignment algorithms/compare algorithms/sorting algorithms/alignment/sdp algorithms/anchoring; do
 	mkdir -p "$g_installbuild_dir/include/alignment/$i"
-	cp -a "${g_git_build_srcdir}/$i"/*.hpp "$g_installbuild_dir/include/alignment/$i"
+	cp -a "${g_srcdir_abs}/$i"/*.hpp "$g_installbuild_dir/include/alignment/$i"
     done
     for i in tuples datastructures/alignment; do
 	mkdir -p "$g_installbuild_dir/include/alignment/$i"
-	cp -a "${g_git_build_srcdir}/$i"/*.h "$g_installbuild_dir/include/alignment/$i"
+	cp -a "${g_srcdir_abs}/$i"/*.h "$g_installbuild_dir/include/alignment/$i"
     done
 
 }

--- a/sh/mobs/pacbio/libblasr/buildctl.sh
+++ b/sh/mobs/pacbio/libblasr/buildctl.sh
@@ -139,7 +139,9 @@ set -x
 	LIBBLASR_LIB="${g_installbuild_dir}/lib/" \
 	${1+"$@"}
 
-    eval "$g_make_exe" -C "$g_unittest_outdir" gtest
+    eval "$g_make_exe" -C "$g_unittest_outdir" \
+        -j4 \
+        gtest
 set +x
 
     # clean installunittest dir ~hm
@@ -171,7 +173,7 @@ install_build() {
     mkdir -p "$g_installbuild_dir/include"        
     # FIXME: Is there a better way to specify all the include headers that
     #        we need to export to other programs that depend on libblasr??
-    for i in . utils statistics tuples format files suffixarray ipc bwt datastructures/anchoring datastructures/alignment datastructures/alignmentset algorithms/alignment algorithms/compare algorithms/sorting algorithms/alignment/sdp algorithms/anchoring; do
+    for i in . utils statistics tuples format files suffixarray ipc bwt datastructures/anchoring datastructures/alignment datastructures/alignmentset algorithms/alignment algorithms/compare algorithms/sorting algorithms/alignment/sdp algorithms/anchoring simulator; do
 	mkdir -p "$g_installbuild_dir/include/alignment/$i"
 	cp -a "${g_srcdir_abs}/$i"/*.hpp "$g_installbuild_dir/include/alignment/$i"
     done

--- a/sh/mobs/pacbio/libblasr/buildctl.sh
+++ b/sh/mobs/pacbio/libblasr/buildctl.sh
@@ -18,6 +18,7 @@ set_globals() {
 
 	g_git_exe=$MOBS_git__git_exe
 
+    g_gcc_runtime_libdir_abs=$MOBS_gcc__runtimelib_dir
 	g_boost_rootdir_abs=$MOBS_boost__root_dir
 	g_zlib_rootdir_abs=$MOBS_zlib__install_dir
 	g_hdf5_rootdir_abs=$MOBS_hdf5__install_dir
@@ -157,9 +158,12 @@ set -x
 	HDF5_LIB="${g_outdir_abs}/deplinks/hdf5/lib/libhdf5.so" \
 	HDF5_CPP_LIB="${g_outdir_abs}/deplinks/hdf5/lib/libhdf5_cpp.so" \
 	ZLIB_LIB="${g_outdir_abs}/deplinks/zlib/lib/libz.so" \
+    GCC_LIB=\"$g_gcc_runtime_libdir_abs\" \
 	V=1 \
 	${1+"$@"} gtest
 set +x
+    # Note: GCC_LIB is *already* just a directory. We will fix the others later, to be
+    # consistent with blasr.
 
     # clean installunittest dir
     rm -rf "$g_installunittest_dir";


### PR DESCRIPTION
Related to
* https://github.com/PacificBiosciences/blasr_libcpp/pull/36

I also have some changes for blasr, which may or may not need GCC_LIB. Hopefully we are close to done with this.